### PR TITLE
GetPagedResults: fix bug causing 2nd page to be fetched in a loop

### DIFF
--- a/src/Bitbucket.Cloud.Net/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/BitbucketCloudClient.cs
@@ -94,7 +94,7 @@ namespace Bitbucket.Cloud.Net
 			while (!isLastPage && (maxPages == null || numPages < maxPages))
 			{
 				var selectorResults = await selector(queryParamValues).ConfigureAwait(false);
-				selectorResults.Page = Math.Max(0, 1);
+				selectorResults.Page = Math.Max(selectorResults.Page, 1);
 				results.AddRange(selectorResults.Values);
 
 				isLastPage = selectorResults.Next == null;


### PR DESCRIPTION
Currently GetPagedResults assigns selectorResults.Page to `Math.Max(0, 1)` which always evaluates to 1, causing the next page to always be page 2. This results in a loop where the second page is repeatedly fetched until the server kicks you out for violating the API rate limit. 

The fix assigns the page number to be 1 only when it is less than 1, i.e. missing. 