### PR TITLE
Bug: I always got an 500 internal server error when sending paged requests

### DIFF
--- a/src/Bitbucket.Cloud.Net/v2/HookEvents/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/HookEvents/BitbucketCloudClient.cs
@@ -23,12 +23,9 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<HookEvent>> GetHookEventsAsync(HookEventSubjectTypes hookEventSubjectType, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
 			var subjectType = HookEventSubjectTypeConverter.ConvertToString(hookEventSubjectType);
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetHookEventsUrl(subjectType)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetHookEventsUrl(subjectType), async req =>
+					await req
 						.GetJsonAsync<PagedResults<HookEvent>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/PullRequests/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/PullRequests/BitbucketCloudClient.cs
@@ -23,9 +23,9 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetPullRequestsUrl(userName)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetPullRequestsUrl(userName), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<PullRequest>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/BitbucketCloudClient.cs
@@ -26,9 +26,9 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetRepositoriesUrl()
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetRepositoriesUrl(), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<Repository>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -43,9 +43,9 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetRepositoriesUrl($"/{workspaceId}")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetRepositoriesUrl($"/{workspaceId}"), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<Repository>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/BranchRestrictions/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/BranchRestrictions/BitbucketCloudClient.cs
@@ -31,9 +31,9 @@ namespace Bitbucket.Cloud.Net
 				[nameof(pattern)] = pattern
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetBranchRestrictionsUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetBranchRestrictionsUrl(workspaceId, repositorySlug), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<BranchRestriction>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Commit/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Commit/BitbucketCloudClient.cs
@@ -40,17 +40,10 @@ namespace Bitbucket.Cloud.Net
 			return await HandleResponseAsync(response).ConfigureAwait(false);
 		}
 
-		public async Task<IEnumerable<PullRequestInfo>> GetRepositoryCommitPullRequestsAsync(string workspaceId, string repositorySlug, string commit, int? maxPages = null, int? page = null, int? pageLength = null)
+		public async Task<IEnumerable<PullRequestInfo>> GetRepositoryCommitPullRequestsAsync(string workspaceId, string repositorySlug, string commit, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>
-			{
-				[nameof(page)] = page,
-				["pagelen"] = pageLength
-			};
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetCommitUrl(workspaceId, repositorySlug, commit, "/pullrequests")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetCommitUrl(workspaceId, repositorySlug, commit, "/pullrequests"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<PullRequestInfo>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -98,9 +91,9 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetCommitUrl(workspaceId, repositorySlug, commit, "/comments")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetCommitUrl(workspaceId, repositorySlug, commit, "/comments"), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<Comment>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -121,9 +114,9 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetCommitUrl(workspaceId, repositorySlug, commit, "/statuses")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetCommitUrl(workspaceId, repositorySlug, commit, "/statuses"), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<BuildResult>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Commits/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Commits/BitbucketCloudClient.cs
@@ -24,9 +24,9 @@ namespace Bitbucket.Cloud.Net
 				["exclude"] = excludes
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetCommitsUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetCommitsUrl(workspaceId, repositorySlug), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<Commit>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -42,9 +42,9 @@ namespace Bitbucket.Cloud.Net
 				["exclude"] = excludes
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetCommitsUrl(workspaceId, repositorySlug, reference)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetCommitsUrl(workspaceId, repositorySlug, reference), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<Commit>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Components/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Components/BitbucketCloudClient.cs
@@ -13,11 +13,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Component>> GetRepositoryComponentsAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetComponentsUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetComponentsUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Component>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/DefaultReviewers/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/DefaultReviewers/BitbucketCloudClient.cs
@@ -17,11 +17,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<User>> GetRepositoryDefaultReviewersAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetDefaultReviewersUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetDefaultReviewersUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<User>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/DeployKeys/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/DeployKeys/BitbucketCloudClient.cs
@@ -31,11 +31,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<DeployKey>> GetRepositoryDeployKeysAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetDeployKeysUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetDeployKeysUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<DeployKey>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Deployments/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Deployments/BitbucketCloudClient.cs
@@ -17,11 +17,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Deployment>> GetRepositoryDeploymentsAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetDeploymentsUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetDeploymentsUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Deployment>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/DeploymentsConfig/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/DeploymentsConfig/BitbucketCloudClient.cs
@@ -26,11 +26,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Variable>> GetRepositoryDeploymentsConfigVariablesAsync(string workspaceId, string repositorySlug, Guid environmentUuid, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetDeploymentsConfigUrl(workspaceId, repositorySlug, $"/environments/{environmentUuid:B}/variables")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetDeploymentsConfigUrl(workspaceId, repositorySlug, $"/environments/{environmentUuid:B}/variables"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Variable>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/DiffStat/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/DiffStat/BitbucketCloudClient.cs
@@ -18,9 +18,9 @@ namespace Bitbucket.Cloud.Net
 				["ignore_whitespace"] = ignoreWhiteSpace
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetDiffStatUrl(workspaceId, repositorySlug, spec)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetDiffStatUrl(workspaceId, repositorySlug, spec), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<DiffStat>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Downloads/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Downloads/BitbucketCloudClient.cs
@@ -26,11 +26,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Download>> GetRepositoryDownloadsAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetDownloadsUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetDownloadsUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Download>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Environments/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Environments/BitbucketCloudClient.cs
@@ -28,11 +28,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Environment>> GetRepositoryEnvironmentsAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetEnvironmentsUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetEnvironmentsUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Environment>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/FileHistory/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/FileHistory/BitbucketCloudClient.cs
@@ -19,9 +19,9 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetFileHistoryUrl(workspaceId, repositorySlug, node, path)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetFileHistoryUrl(workspaceId, repositorySlug, node, path), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<FileHistoryItem>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Forks/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Forks/BitbucketCloudClient.cs
@@ -22,11 +22,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Fork>> GetRepositoryForksAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetForksUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetForksUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Fork>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Hooks/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Hooks/BitbucketCloudClient.cs
@@ -26,11 +26,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Webhook>> GetRepositoryWebhooksAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetHooksUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetHooksUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Webhook>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Issues/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Issues/BitbucketCloudClient.cs
@@ -29,11 +29,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Issue>> GetRepositoryIssuesAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetIssuesUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetIssuesUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Issue>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -120,12 +117,10 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<IssueAttachment>> GetRepositoryIssueAttachmentsAsync(string workspaceId, string repositorySlug, string issueId, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetIssuesUrl(workspaceId, repositorySlug, issueId)
-						.AppendPathSegment("/attachments")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, 
+                        GetIssuesUrl(workspaceId, repositorySlug, issueId)
+                        .AppendPathSegment("/attachments"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<IssueAttachment>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -167,10 +162,11 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetIssuesUrl(workspaceId, repositorySlug, issueId)
-						.AppendPathSegment("/changes")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, 
+                         GetIssuesUrl(workspaceId, repositorySlug, issueId)
+                        .AppendPathSegment("/changes"), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<IssueChange>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -202,10 +198,11 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetIssuesUrl(workspaceId, repositorySlug, issueId)
-						.AppendPathSegment("/comments")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, 
+                        GetIssuesUrl(workspaceId, repositorySlug, issueId)
+                        .AppendPathSegment("/comments"), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<IssueComment>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Milestones/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Milestones/BitbucketCloudClient.cs
@@ -16,11 +16,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Milestone>> GetRepositoryMilestonesAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetMilestonesUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetMilestonesUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Milestone>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Pipelines/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Pipelines/BitbucketCloudClient.cs
@@ -24,11 +24,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Pipeline>> GetRepositoryPipelinesAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetPipelinesUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetPipelinesUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Pipeline>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -52,11 +49,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<PipelineStep>> GetRepositoryPipelineStepsAsync(string workspaceId, string repositorySlug, Guid pipelineUuid, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetPipelineStepsUrl(workspaceId, repositorySlug, pipelineUuid)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetPipelineStepsUrl(workspaceId, repositorySlug, pipelineUuid), async req =>
+					await req
 						.GetJsonAsync<PagedResults<PipelineStep>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/PipelinesConfig/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/PipelinesConfig/BitbucketCloudClient.cs
@@ -57,11 +57,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<PipelineSchedule>> GetRepositoryPipelinesConfigSchedulesAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetPipelinesConfigSchedulesUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetPipelinesConfigSchedulesUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<PipelineSchedule>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -95,11 +92,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<PipelineScheduleExecution>> GetRepositoryPipelinesConfigScheduleExecutionsAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetPipelinesConfigSchedulesUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetPipelinesConfigSchedulesUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<PipelineScheduleExecution>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -141,11 +135,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<PipelineKnownHost>> GetRepositoryPipelinesConfigKnownHostsAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetPipelinesConfigSshKnownHostsUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetPipelinesConfigSshKnownHostsUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<PipelineKnownHost>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -187,11 +178,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Variable>> GetRepositoryPipelinesConfigVariablesAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetPipelinesConfigVariablesUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetPipelinesConfigVariablesUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Variable>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/PullRequests/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/PullRequests/BitbucketCloudClient.cs
@@ -35,11 +35,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<PullRequest>> GetRepositoryPullRequestsAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetPullRequestsUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetPullRequestsUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<PullRequest>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -47,11 +44,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<PullRequestActivity>> GetRepositoryPullRequestActivityAsync(string workspaceId, string repositorySlug, string pullRequestId, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetPullRequestsUrl(workspaceId, repositorySlug, $"/{pullRequestId}/activity")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetPullRequestsUrl(workspaceId, repositorySlug, $"/{pullRequestId}/activity"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<PullRequestActivity>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -102,11 +96,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<PullRequestComment>> GetRepositoryPullRequestCommentsAsync(string workspaceId, string repositorySlug, string pullRequestId, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetPullRequestsUrl(workspaceId, repositorySlug, $"/{pullRequestId}/comments")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetPullRequestsUrl(workspaceId, repositorySlug, $"/{pullRequestId}/comments"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<PullRequestComment>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -139,11 +130,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Commit>> GetRepositoryPullRequestCommitsAsync(string workspaceId, string repositorySlug, string pullRequestId, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetPullRequestsUrl(workspaceId, repositorySlug, $"/{pullRequestId}/commits")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetPullRequestsUrl(workspaceId, repositorySlug, $"/{pullRequestId}/commits"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Commit>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -167,11 +155,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<DiffStat>> GetRepositoryPullRequestDiffStatAsync(string workspaceId, string repositorySlug, string pullRequestId, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetPullRequestsUrl(workspaceId, repositorySlug, $"/{pullRequestId}/diffstat")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetPullRequestsUrl(workspaceId, repositorySlug, $"/{pullRequestId}/diffstat"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<DiffStat>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -208,9 +193,9 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetPullRequestsUrl(workspaceId, repositorySlug, $"/{pullRequestId}/statuses")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetPullRequestsUrl(workspaceId, repositorySlug, $"/{pullRequestId}/statuses"), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<BuildResult>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Refs/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Refs/BitbucketCloudClient.cs
@@ -26,9 +26,9 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetRefsUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetRefsUrl(workspaceId, repositorySlug), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<Ref>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -60,9 +60,9 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetRefsBranchesUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetRefsBranchesUrl(workspaceId, repositorySlug), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<Ref>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -94,9 +94,9 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetRefsTagsUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetRefsTagsUrl(workspaceId, repositorySlug), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<Ref>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Src/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Src/BitbucketCloudClient.cs
@@ -14,11 +14,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Source>> GetRepositorySourceAsync(string workspaceId, string repositorySlug, SourceFormats? format = null, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetSourceUrl(workspaceId, repositorySlug, format)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetSourceUrl(workspaceId, repositorySlug, format), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Source>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Versions/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Versions/BitbucketCloudClient.cs
@@ -13,11 +13,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Version>> GetRepositoryVersionsAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetVersionsUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetVersionsUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Version>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Watchers/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Watchers/BitbucketCloudClient.cs
@@ -13,11 +13,8 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<User>> GetRepositoryWatchersAsync(string workspaceId, string repositorySlug, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetWatchersUrl(workspaceId, repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetWatchersUrl(workspaceId, repositorySlug), async req =>
+					await req
 						.GetJsonAsync<PagedResults<User>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Snippets/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Snippets/BitbucketCloudClient.cs
@@ -35,9 +35,9 @@ namespace Bitbucket.Cloud.Net
 				[nameof(role)] = RolesConverter.ConvertToString(role)
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetSnippetsUrl()
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetSnippetsUrl(), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<Snippet>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -59,9 +59,9 @@ namespace Bitbucket.Cloud.Net
 				[nameof(role)] = RolesConverter.ConvertToString(role)
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetSnippetsUrl(workspaceId)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetSnippetsUrl(workspaceId), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<Snippet>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -131,11 +131,12 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetSnippetsUrl(workspaceId)
-						.AppendPathSegment(snippetId)
-						.AppendPathSegment("/comments")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, 
+                        GetSnippetsUrl(workspaceId)
+                        .AppendPathSegment(snippetId)
+                        .AppendPathSegment("/comments"), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<SnippetComment>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -179,11 +180,12 @@ namespace Bitbucket.Cloud.Net
 		{
 			var queryParamValues = new Dictionary<string, object>();
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetSnippetsUrl(workspaceId)
-						.AppendPathSegment(snippetId)
-						.AppendPathSegment("/commits")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, 
+                        GetSnippetsUrl(workspaceId)
+                        .AppendPathSegment(snippetId)
+                        .AppendPathSegment("/commits"), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<SnippetCommit>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -244,13 +246,11 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<User>> GetWorkspaceSnippetWatchersAsync(string workspaceId, string snippetId, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetSnippetsUrl(workspaceId)
-						.AppendPathSegment(snippetId)
-						.AppendPathSegment("/watchers")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, 
+                        GetSnippetsUrl(workspaceId)
+                        .AppendPathSegment(snippetId)
+                        .AppendPathSegment("/watchers"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<User>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Teams/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Teams/BitbucketCloudClient.cs
@@ -21,9 +21,9 @@ namespace Bitbucket.Cloud.Net
 				[nameof(role)] = PermissionsConverter.ToString(role)
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetTeamsUrl()
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, GetTeamsUrl(), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<Team>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -38,12 +38,10 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<User>> GetTeamFollowersAsync(string teamName, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetTeamsUrl(teamName)
-						.AppendPathSegment("/followers")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, 
+                        GetTeamsUrl(teamName)
+                        .AppendPathSegment("/followers"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<User>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -51,12 +49,10 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<User>> GetTeamFollowingAsync(string teamName, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetTeamsUrl(teamName)
-						.AppendPathSegment("/following")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, 
+                        GetTeamsUrl(teamName)
+                        .AppendPathSegment("/following"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<User>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -74,12 +70,10 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Webhook>> GetTeamWebhooksAsync(string userName, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetTeamsUrl()
-						.AppendPathSegment($"/{userName}/hooks")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, 
+                        GetTeamsUrl()
+                        .AppendPathSegment($"/{userName}/hooks"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Webhook>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -121,10 +115,11 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetTeamsUrl(userName)
-						.AppendPathSegment("/permissions")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, 
+                         GetTeamsUrl(userName)
+                        .AppendPathSegment("/permissions"), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<TeamPermission>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -138,11 +133,12 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetTeamsUrl(userName)
-						.AppendPathSegment("/permissions")
-						.AppendPathSegment("/repositories")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, 
+                        GetTeamsUrl(userName)
+                        .AppendPathSegment("/permissions")
+                        .AppendPathSegment("/repositories"), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<TeamRepositoryPermission>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -156,12 +152,13 @@ namespace Bitbucket.Cloud.Net
 				[nameof(sort)] = sort
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetTeamsUrl(userName)
-						.AppendPathSegment("/permissions")
-						.AppendPathSegment("/repositories")
-						.AppendPathSegment(repositorySlug)
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages,
+                         GetTeamsUrl(userName)
+                        .AppendPathSegment("/permissions")
+                        .AppendPathSegment("/repositories")
+                        .AppendPathSegment(repositorySlug), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<TeamRepositoryPermission>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -179,12 +176,10 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Variable>> GetTeamVariablesAsync(string userName, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetTeamsUrl()
-						.AppendPathSegment($"/{userName}/pipelines_config/variables/")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages,
+                         GetTeamsUrl()
+                        .AppendPathSegment($"/{userName}/pipelines_config/variables/"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Variable>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -230,12 +225,10 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Project>> GetTeamProjectsAsync(string teamName, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetTeamsUrl(teamName)
-						.AppendPathSegment("/projects")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages, 
+                         GetTeamsUrl(teamName)
+                        .AppendPathSegment("/projects"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Project>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -271,30 +264,27 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Repository>> GetTeamRepositoriesAsync(string userName, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetTeamsUrl()
-						.AppendPathSegment($"/{userName}/repositories")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages,
+                         GetTeamsUrl()
+                        .AppendPathSegment($"/{userName}/repositories"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Repository>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
 		}
 
-		public async Task<IEnumerable<SearchResult>> SearchTeamCodeAsync(string teamName, string searchQuery, int? maxPages = null, int? page = null, int? pageLength = null)
+		public async Task<IEnumerable<SearchResult>> SearchTeamCodeAsync(string teamName, string searchQuery, int? maxPages = null)
 		{
 			var queryParamValues = new Dictionary<string, object>
 			{
-				["search_query"] = searchQuery,
-				["page"] = page,
-				["pagelen"] = pageLength
+				["search_query"] = searchQuery
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetTeamsUrl()
-						.AppendPathSegment($"/{teamName}/search/code")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages,
+                         GetTeamsUrl()
+                        .AppendPathSegment($"/{teamName}/search/code"), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<SearchResult>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/User/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/User/BitbucketCloudClient.cs
@@ -20,12 +20,10 @@ namespace Bitbucket.Cloud.Net
 
         public async Task<IEnumerable<UserEmail>> GetUserEmailsAsync(int? maxPages = null)
         {
-            var queryParamValues = new Dictionary<string, object>();
-
-            return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-                    await GetUserUrl()
-                        .AppendPathSegment("/emails")
-                        .SetQueryParams(qpv)
+            return await GetPagedResultsAsync(maxPages, 
+                         GetUserUrl()
+                        .AppendPathSegment("/emails"), async req =>
+                    await req
                         .GetJsonAsync<PagedResults<UserEmail>>()
                         .ConfigureAwait(false))
                 .ConfigureAwait(false);
@@ -41,12 +39,10 @@ namespace Bitbucket.Cloud.Net
 
         public async Task<IEnumerable<UserPermissionRepository>> GetUserPermissionsForRepositoriesAsync(int? maxPages = null)
         {
-            var queryParamValues = new Dictionary<string, object>();
-
-            return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-                    await GetUserUrl()
-                        .AppendPathSegment("/permissions/repositories")
-                        .SetQueryParams(qpv)
+            return await GetPagedResultsAsync(maxPages,
+                         GetUserUrl()
+                        .AppendPathSegment("/permissions/repositories"), async req =>
+                    await req
                         .GetJsonAsync<PagedResults<UserPermissionRepository>>()
                         .ConfigureAwait(false))
                 .ConfigureAwait(false);
@@ -54,12 +50,10 @@ namespace Bitbucket.Cloud.Net
 
         public async Task<IEnumerable<UserPermissionTeam>> GetUserPermissionsForTeamsAsync(int? maxPages = null)
         {
-            var queryParamValues = new Dictionary<string, object>();
-
-            return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-                    await GetUserUrl()
-                        .AppendPathSegment("/permissions/teams")
-                        .SetQueryParams(qpv)
+            return await GetPagedResultsAsync(maxPages,
+                         GetUserUrl()
+                        .AppendPathSegment("/permissions/teams"), async req =>
+                    await req
                         .GetJsonAsync<PagedResults<UserPermissionTeam>>()
                         .ConfigureAwait(false))
                 .ConfigureAwait(false);

--- a/src/Bitbucket.Cloud.Net/v2/Users/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Users/BitbucketCloudClient.cs
@@ -31,12 +31,10 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Webhook>> GetUserWebhooksAsync(string userName, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetUsersUrl()
-						.AppendPathSegment($"/{userName}/hooks")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages,
+                         GetUsersUrl()
+                        .AppendPathSegment($"/{userName}/hooks"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Webhook>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -82,12 +80,10 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Variable>> GetUserVariablesAsync(string userName, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetUsersUrl()
-						.AppendPathSegment($"/{userName}/pipelines_config/variables/")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages,
+                         GetUsersUrl()
+                        .AppendPathSegment($"/{userName}/pipelines_config/variables/"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Variable>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -151,30 +147,27 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<Repository>> GetUserRepositoriesAsync(string userName, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetUsersUrl()
-						.AppendPathSegment($"/{userName}/repositories")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages,
+                         GetUsersUrl()
+                        .AppendPathSegment($"/{userName}/repositories"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<Repository>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
 		}
 
-		public async Task<IEnumerable<SearchResult>> SearchCodeAsync(string userName, string searchQuery, int? maxPages = null, int? page = null, int? pageLength = null)
+		public async Task<IEnumerable<SearchResult>> SearchCodeAsync(string userName, string searchQuery, int? maxPages = null)
 		{
 			var queryParamValues = new Dictionary<string, object>
 			{
-				["search_query"] = searchQuery,
-				["page"] = page,
-				["pagelen"] = pageLength
+				["search_query"] = searchQuery
 			};
 
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetUsersUrl()
-						.AppendPathSegment($"/{userName}/search/code")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages,
+                         GetUsersUrl()
+                        .AppendPathSegment($"/{userName}/search/code"), async req =>
+					await req
+						.SetQueryParams(queryParamValues)
 						.GetJsonAsync<PagedResults<SearchResult>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);
@@ -192,12 +185,10 @@ namespace Bitbucket.Cloud.Net
 
 		public async Task<IEnumerable<SshKey>> GetUserSshKeysAsync(string userName, int? maxPages = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
-
-			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
-					await GetUsersUrl()
-						.AppendPathSegment($"/{userName}/ssh-keys")
-						.SetQueryParams(qpv)
+			return await GetPagedResultsAsync(maxPages,
+                         GetUsersUrl()
+                        .AppendPathSegment($"/{userName}/ssh-keys"), async req =>
+					await req
 						.GetJsonAsync<PagedResults<SshKey>>()
 						.ConfigureAwait(false))
 				.ConfigureAwait(false);


### PR DESCRIPTION
Fix: Always use "next" property from response of paged requests. API reference: next: Link to the next page if it exists. The last page of a collection does not have this value. Use this link to navigate the result set and refrain from constructing your own URLs.)