### PR TITLE
Fix branch model settings not posting correct format + response

### DIFF
--- a/src/Bitbucket.Cloud.Net/Models/v2/BranchTypePrefix.cs
+++ b/src/Bitbucket.Cloud.Net/Models/v2/BranchTypePrefix.cs
@@ -1,7 +1,11 @@
-﻿namespace Bitbucket.Cloud.Net.Models.v2
+﻿using Bitbucket.Cloud.Net.Common.Converters;
+using Newtonsoft.Json;
+
+namespace Bitbucket.Cloud.Net.Models.v2
 {
 	public class BranchTypeInfo
 	{
+		[JsonConverter(typeof(BranchTypesConverter))]
 		public BranchTypes Kind { get; set; }
 		public string Prefix { get; set; }
 		public bool? Enabled { get; set; }

--- a/src/Bitbucket.Cloud.Net/v2/Repositories/BranchingModel/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/BranchingModel/BitbucketCloudClient.cs
@@ -16,14 +16,14 @@ namespace Bitbucket.Cloud.Net
 				.ConfigureAwait(false);
 		}
 
-		public async Task<string> UpdateRepositoryBranchingModelSettingsAsync(string workspaceId, string repositorySlug, BranchingModel branchingModel)
+		public async Task<BranchingModel> UpdateRepositoryBranchingModelSettingsAsync(string workspaceId, string repositorySlug, BranchingModel branchingModel)
 		{
 			var response = await GetBranchingModelUrl(workspaceId, repositorySlug)
 				.AppendPathSegment("/settings")
 				.PutJsonAsync(branchingModel)
 				.ConfigureAwait(false);
 
-			return await HandleResponseAsync<string>(response);
+			return await HandleResponseAsync<BranchingModel>(response);
 		}
 
 		public async Task<BranchingModel> GetRepositoryBranchingModelSettingsAsync(string workspaceId, string repositorySlug)


### PR DESCRIPTION
Branch model settings expected "hotfix"/"feature" etc for the BranchTypes, and the enum wasn't being serialized correctly so it was sending 1/2/3/4, resulting in:
![image](https://user-images.githubusercontent.com/15220647/97055990-e860e600-1555-11eb-8a93-bb5bb06bcded.png)

Additionally, the API returns the new branch model back to you, which can be deserialized back into a BranchModel object.