### PR TITLE
Allow passing query param to GetRepositoryPullRequestsAsync

### DIFF
--- a/src/Bitbucket.Cloud.Net/v2/Repositories/PullRequests/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/PullRequests/BitbucketCloudClient.cs
@@ -34,9 +34,12 @@ namespace Bitbucket.Cloud.Net
 			return await HandleResponseAsync<PullRequest>(response).ConfigureAwait(false);
 		}
 
-		public async Task<IEnumerable<PullRequest>> GetRepositoryPullRequestsAsync(string workspaceId, string repositorySlug, int? maxPages = null)
+		public async Task<IEnumerable<PullRequest>> GetRepositoryPullRequestsAsync(string workspaceId, string repositorySlug, int? maxPages = null, string q = null)
 		{
-			var queryParamValues = new Dictionary<string, object>();
+			var queryParamValues = new Dictionary<string, object>
+			{
+				[nameof(q)] = q
+			};
 
 			return await GetPagedResultsAsync(maxPages, queryParamValues, async qpv =>
 					await GetPullRequestsUrl(workspaceId, repositorySlug)


### PR DESCRIPTION
This allows passing in query params to the GetRepositoryPullRequestsAsync method, so you can filter to things like only pull requests with state "OPEN" or only pull requests targeting specific branches.