### PR TITLE
bugfix: bitbucket paged results, use next page id versus incrementing…

### DIFF
--- a/src/Bitbucket.Cloud.Net/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/BitbucketCloudClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Bitbucket.Cloud.Net.Common;
@@ -13,100 +14,110 @@ using Newtonsoft.Json.Serialization;
 
 namespace Bitbucket.Cloud.Net
 {
-	public partial class BitbucketCloudClient
-	{
-		private static readonly ISerializer s_serializer = new NewtonsoftJsonSerializer(new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
+    public partial class BitbucketCloudClient
+    {
+        private static readonly ISerializer s_serializer = new NewtonsoftJsonSerializer(new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
 
-		private readonly Url _url;
-		private readonly AuthenticationMethod _auth;
+        private readonly Url _url;
+        private readonly AuthenticationMethod _auth;
 
-		private BitbucketCloudClient(string url)
-		{
-			_url = url;
-		}
+        private BitbucketCloudClient(string url)
+        {
+            _url = url;
+        }
 
-		public BitbucketCloudClient(string url, OAuthAuthentication oauth)
-			: this(url)
-		{
-			_auth = oauth;
-		}
+        public BitbucketCloudClient(string url, OAuthAuthentication oauth)
+            : this(url)
+        {
+            _auth = oauth;
+        }
 
-		public BitbucketCloudClient(string url, AppPasswordAuthentication appPassword)
-			: this(url)
-		{
-			_auth = appPassword;
-		}
+        public BitbucketCloudClient(string url, AppPasswordAuthentication appPassword)
+            : this(url)
+        {
+            _auth = appPassword;
+        }
 
-		public BitbucketCloudClient(string url, BasicAuthentication basic)
-			: this(url)
-		{
-			_auth = basic;
-		}
+        public BitbucketCloudClient(string url, BasicAuthentication basic)
+            : this(url)
+        {
+            _auth = basic;
+        }
 
-		public IFlurlRequest GetBaseUrl(string path) => new Url(_url)
-			.AppendPathSegment(path)
-			.ConfigureRequest(settings => settings.JsonSerializer = s_serializer)
-			.WithAuthentication(_auth);
+        public IFlurlRequest GetBaseUrl(string path) => new Url(_url)
+            .AppendPathSegment(path)
+            .ConfigureRequest(settings => settings.JsonSerializer = s_serializer)
+            .WithAuthentication(_auth);
 
-		private async Task<TResult> ReadResponseContentAsync<TResult>(HttpResponseMessage responseMessage, Func<string, TResult> contentHandler = null)
-		{
-			string content = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
-			return contentHandler != null
-				? contentHandler(content)
-				: JsonConvert.DeserializeObject<TResult>(content);
-		}
+        private async Task<TResult> ReadResponseContentAsync<TResult>(HttpResponseMessage responseMessage, Func<string, TResult> contentHandler = null)
+        {
+            string content = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return contentHandler != null
+                ? contentHandler(content)
+                : JsonConvert.DeserializeObject<TResult>(content);
+        }
 
-		private async Task<bool> ReadResponseContentAsync(HttpResponseMessage responseMessage)
-		{
-			string content = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
-			return content.Length == 0;
-		}
+        private async Task<bool> ReadResponseContentAsync(HttpResponseMessage responseMessage)
+        {
+            string content = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return content.Length == 0;
+        }
 
-		private async Task HandleErrorsAsync(HttpResponseMessage response)
-		{
-			if (!response.IsSuccessStatusCode)
-			{
-				var errorResponse = await ReadResponseContentAsync<ErrorResponse>(response).ConfigureAwait(false);
+        private async Task HandleErrorsAsync(HttpResponseMessage response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorResponse = await ReadResponseContentAsync<ErrorResponse>(response).ConfigureAwait(false);
 
-				string errorMessage = string.Join(Environment.NewLine, errorResponse?.Error?.Message);
-				throw new InvalidOperationException($"Http request failed ({(int)response.StatusCode} - {response.StatusCode}):\n{errorMessage}");
-			}
-		}
+                string errorMessage = string.Join(Environment.NewLine, errorResponse?.Error?.Message);
+                throw new InvalidOperationException($"Http request failed ({(int)response.StatusCode} - {response.StatusCode}):\n{errorMessage}");
+            }
+        }
 
-		private async Task<TResult> HandleResponseAsync<TResult>(HttpResponseMessage responseMessage, Func<string, TResult> contentHandler = null)
-		{
-			await HandleErrorsAsync(responseMessage).ConfigureAwait(false);
-			return await ReadResponseContentAsync(responseMessage, contentHandler).ConfigureAwait(false);
-		}
+        private async Task<TResult> HandleResponseAsync<TResult>(HttpResponseMessage responseMessage, Func<string, TResult> contentHandler = null)
+        {
+            await HandleErrorsAsync(responseMessage).ConfigureAwait(false);
+            return await ReadResponseContentAsync(responseMessage, contentHandler).ConfigureAwait(false);
+        }
 
-		private async Task<bool> HandleResponseAsync(HttpResponseMessage responseMessage)
-		{
-			await HandleErrorsAsync(responseMessage).ConfigureAwait(false);
-			return await ReadResponseContentAsync(responseMessage).ConfigureAwait(false);
-		}
+        private async Task<bool> HandleResponseAsync(HttpResponseMessage responseMessage)
+        {
+            await HandleErrorsAsync(responseMessage).ConfigureAwait(false);
+            return await ReadResponseContentAsync(responseMessage).ConfigureAwait(false);
+        }
 
-		private async Task<IEnumerable<T>> GetPagedResultsAsync<T>(int? maxPages, IDictionary<string, object> queryParamValues, Func<IDictionary<string, object>, Task<PagedResults<T>>> selector)
-		{
-			var results = new List<T>();
-			bool isLastPage = false;
-			int numPages = 0;
+        private async Task<IEnumerable<T>> GetPagedResultsAsync<T>(int? maxPages, IDictionary<string, object> queryParamValues, Func<IDictionary<string, object>, Task<PagedResults<T>>> selector)
+        {
+            var results = new List<T>();
+            bool isLastPage = false;
+            int numPages = 0;
 
-			while (!isLastPage && (maxPages == null || numPages < maxPages))
-			{
-				var selectorResults = await selector(queryParamValues).ConfigureAwait(false);
-				selectorResults.Page = Math.Max(selectorResults.Page, 1);
-				results.AddRange(selectorResults.Values);
+            while (!isLastPage && (maxPages == null || numPages < maxPages))
+            {
+                var selectorResults = await selector(queryParamValues).ConfigureAwait(false);
+                selectorResults.Page = Math.Max(selectorResults.Page, 1);
+                results.AddRange(selectorResults.Values);
 
-				isLastPage = selectorResults.Next == null || selectorResults.Size == numPages * selectorResults.PageLen;
-				if (!isLastPage)
-				{
-					queryParamValues["page"] = selectorResults.Page + 1;
-				}
+                isLastPage = selectorResults.Next == null;
 
-				numPages++;
-			}
+                // parse out the next page id from the results
+                if (!isLastPage)
+                {
+                    var myUri = new Uri(selectorResults.Next);
+                    var nextPage = myUri.DecodeQueryParameters().FirstOrDefault(x => x.Key == "page");
 
-			return results;
-		}
-	}
+                    if (nextPage.Value != null)
+                        queryParamValues["page"] = nextPage.Value;
+                    else
+                        isLastPage = true;
+                }
+
+                numPages++;
+            }
+
+            return results;
+        }
+    }
+
+
 }

--- a/src/Bitbucket.Cloud.Net/Common/UriExtensions.cs
+++ b/src/Bitbucket.Cloud.Net/Common/UriExtensions.cs
@@ -1,10 +1,29 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Bitbucket.Cloud.Net.Common
 {
-	public static class UriExtensions
-	{
-		public static string GetLastPathSegment(this string s) => new Uri(s).Segments.LastOrDefault();
-	}
+    public static class UriExtensions
+    {
+        public static string GetLastPathSegment(this string s) => new Uri(s).Segments.LastOrDefault();
+
+
+        public static Dictionary<string, string> DecodeQueryParameters(this Uri uri)
+        {
+            if (uri == null)
+                throw new ArgumentNullException("uri");
+
+            if (uri.Query.Length == 0)
+                return new Dictionary<string, string>();
+
+            return uri.Query.TrimStart('?')
+                .Split(new[] { '&', ';' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(parameter => parameter.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries))
+                .GroupBy(parts => parts[0],
+                    parts => parts.Length > 2 ? string.Join("=", parts, 1, parts.Length - 1) : (parts.Length > 1 ? parts[1] : ""))
+                .ToDictionary(grouping => grouping.Key,
+                    grouping => string.Join(",", grouping));
+        }
+    }
 }


### PR DESCRIPTION
When making the request..

https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pullrequests/#api-repositories-workspace-repo-slug-pullrequests-pull-request-id-comments-get

the next page id was alphanumeric id, grabbed from the "next" page url.

Update api client to parse out the "next" page parameter and use that versus incrementing the page id.

[… integer to support bitbucket paged alphanumeric ids](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#pagination)

