### PR TITLE
Remove return type from DeleteRepositoryWebhookAsync

### DIFF
--- a/src/Bitbucket.Cloud.Net/v2/Repositories/Hooks/BitbucketCloudClient.cs
+++ b/src/Bitbucket.Cloud.Net/v2/Repositories/Hooks/BitbucketCloudClient.cs
@@ -52,13 +52,13 @@ namespace Bitbucket.Cloud.Net
 				.ConfigureAwait(false);
 		}
 
-		public async Task<bool> DeleteRepositoryWebhookAsync(string workspaceId, string repositorySlug, string webhookId)
+		public async Task DeleteRepositoryWebhookAsync(string workspaceId, string repositorySlug, string webhookId)
 		{
 			var response = await GetHooksUrl(workspaceId, repositorySlug, webhookId)
 				.DeleteAsync()
 				.ConfigureAwait(false);
 
-			return await HandleResponseAsync<bool>(response).ConfigureAwait(false);
+			await HandleResponseAsync(response).ConfigureAwait(false);
 		}
 	}
 }


### PR DESCRIPTION
This change modifies the DeleteRepositoryWebhookAsync method to not return any values. The method was previously returning a boolean value, but it has been updated to be a void method. The response handling has also been updated accordingly.

https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-repo-slug-hooks-uid-delete