### PR TITLE
Fix JSON serialization in BranchRestriction model

### DIFF
--- a/src/Bitbucket.Cloud.Net/Models/v2/BranchRestriction.cs
+++ b/src/Bitbucket.Cloud.Net/Models/v2/BranchRestriction.cs
@@ -20,9 +20,9 @@ namespace Bitbucket.Cloud.Net.Models.v2
 
 		public IEnumerable<Group> Groups { get; set; }
 
-		[JsonProperty("branch_type")]
+		[JsonProperty("branch_type", DefaultValueHandling = DefaultValueHandling.Ignore)]
 		[JsonConverter(typeof(BranchTypesConverter))]
-		public BranchTypes BranchType { get; set; }
+		public BranchTypes? BranchType { get; set; }
 
 		public string Type { get; set; }
 		public int Id { get; set; }


### PR DESCRIPTION
Changed the 'BranchType' property in the BranchRestriction model to now be nullable, and to ignore default values when serializing using JsonProperty. This change helps to better handle cases where the 'branch_type' field might not be set.